### PR TITLE
Feat: Transparent background and frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Therefore, if you come up with interesting conditions, I am waiting for contribu
 * [theme](#apply-theme)
 * [margin-w](#margin-width)
 * [margin-h](#margin-height)
+* [no-bg](#transpalent-background)
+* [no-frame](#hide-frame)
 
 
 ## Filter by titles
@@ -301,6 +303,25 @@ https://github-profile-trophy.vercel.app/?username=ryo-ma&column=3&margin-w=15&m
   <img width="360" src="https://user-images.githubusercontent.com/6661165/93668677-ff309a80-fac8-11ea-8ae3-3e3e8adbef39.png">
 </p>
 
+## Transpalent background
+
+You can turn the background transparent.
+`Available value: boolean type (true or false)`
+`Default: no-bg=false`
+
+```
+https://github-profile-trophy.vercel.app/?username=ryo-ma&no-bg=true
+```
+
+## Hide frames
+
+You can hide the frames around the trophies.
+`Available value: boolean type (true or false)`
+`Default: no-frame=false`
+
+```
+https://github-profile-trophy.vercel.app/?username=ryo-ma&no-frame=true
+```
 
 # Contribution Guide
 

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,14 @@ export default async (req: ServerRequest) => {
     "margin-h",
     CONSTANTS.DEFAULT_MARGIN_H,
   );
+  const noBackground = params.getBooleanValue(
+    "no-bg",
+    CONSTANTS.DEFAULT_NO_BACKGROUND,
+  );
+  const noFrame = params.getBooleanValue(
+    "no-frame",
+    CONSTANTS.DEFAULT_NO_FRAME,
+  );
   const titles: Array<string> = params.getAll("title").flatMap((r) =>
     r.split(",")
   ).map((r) => r.trim());
@@ -64,6 +72,8 @@ export default async (req: ServerRequest) => {
         CONSTANTS.DEFAULT_PANEL_SIZE,
         marginWidth,
         paddingHeight,
+        noBackground,
+        noFrame,
       ).render(userInfo, theme),
       headers: new Headers(
         {

--- a/src/card.ts
+++ b/src/card.ts
@@ -27,6 +27,8 @@ export class Card {
     private panelSize: number,
     private marginWidth: number,
     private marginHight: number,
+    private noBackground: boolean,
+    private noFrame: boolean,
   ) {
     this.width = panelSize * this.maxColumn + this.marginWidth * (this.maxColumn - 1);
   }
@@ -92,7 +94,7 @@ export class Card {
         const currentRow = Math.floor(i / this.maxColumn);
         const x = this.panelSize * currentColumn + this.marginWidth * currentColumn;
         const y = this.panelSize * currentRow + this.marginHight * currentRow;
-        return sum + trophy.render(theme, x, y, this.panelSize);
+        return sum + trophy.render(theme, x, y, this.panelSize, this.noBackground, this.noFrame);
       },
       "",
     );

--- a/src/trophies.ts
+++ b/src/trophies.ts
@@ -63,6 +63,8 @@ export class Trophy {
     x = 0,
     y = 0,
     panelSize = CONSTANTS.DEFAULT_PANEL_SIZE,
+    noBackground = CONSTANTS.DEFAULT_NO_BACKGROUND,
+    noFrame = CONSTANTS.DEFAULT_NO_FRAME,
   ): string {
     const { BACKGROUND: PRIMARY, TITLE: SECONDARY, TEXT, NEXT_RANK_BAR } = theme;
     const nextRankBar = getNextRankBar(
@@ -88,7 +90,8 @@ export class Trophy {
             height="${panelSize - 1}"
             stroke="#e1e4e8"
             fill="${PRIMARY}"
-            stroke-opacity="1"
+            stroke-opacity="${noFrame ? '0' : '1'}"
+            fill-opacity="${noBackground ? '0' : '1'}"
           />
           ${getTrophyIcon(theme, this.rank)}
           <text x="50%" y="18" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="13" fill="${SECONDARY}">${this.title}</text>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,13 @@ export class CustomURLSearchParams extends URLSearchParams {
     }
     return defaultValue;
   }
+  getBooleanValue(key: string, defaultValue: boolean): boolean {
+    if (super.has(key)) {
+      const param = super.get(key);
+      return param !== null && param.toString() === 'true';
+    }
+    return defaultValue;
+  }
 }
 
 export function parseParams(req: ServerRequest): CustomURLSearchParams {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,6 +62,8 @@ export const CONSTANTS = {
   DEFAULT_MAX_ROW: 3,
   DEFAULT_MARGIN_W: 0,
   DEFAULT_MARGIN_H: 0,
+  DEFAULT_NO_BACKGROUND: false,
+  DEFAULT_NO_FRAME: false,
 };
 
 export enum RANK {


### PR DESCRIPTION
I wrote some codes about #25 .

New parameters:
- `no-bg=true` to turn the background transparent
- `no-frame=true` to turn the frames transparent

Here are example outputs for my trophies:
```
http://localhost:8080/?username=kawarimidoll&theme=onedark&no-bg=true
```
![no-bg](https://user-images.githubusercontent.com/8146876/104142044-12ab9c80-53fd-11eb-9771-bb7f2f411d9e.png)

```
http://localhost:8080/?username=kawarimidoll&no-frame=true
```
![no-frame](https://user-images.githubusercontent.com/8146876/104142048-15a68d00-53fd-11eb-8c14-4e1aaf4ffbe2.png)



All feedback is welcome!