### PR TITLE
fix typos, remove deprecated HTML attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .env
+.idea

--- a/src/card.ts
+++ b/src/card.ts
@@ -26,7 +26,7 @@ export class Card {
     private maxRow: number,
     private panelSize: number,
     private marginWidth: number,
-    private marginHight: number,
+    private marginHeight: number,
     private noBackground: boolean,
     private noFrame: boolean,
   ) {
@@ -85,7 +85,7 @@ export class Card {
     if (row > this.maxRow) {
       row = this.maxRow;
     }
-    this.height = this.panelSize * row + this.marginHight * (row - 1);
+    this.height = this.panelSize * row + this.marginHeight * (row - 1);
 
     // Join all trophy
     const renderedTrophy = trophyList.reduce(
@@ -93,7 +93,7 @@ export class Card {
         const currentColumn = i % this.maxColumn;
         const currentRow = Math.floor(i / this.maxColumn);
         const x = this.panelSize * currentColumn + this.marginWidth * currentColumn;
-        const y = this.panelSize * currentRow + this.marginHight * currentRow;
+        const y = this.panelSize * currentRow + this.marginHeight * currentRow;
         return sum + trophy.render(theme, x, y, this.panelSize, this.noBackground, this.noFrame);
       },
       "",

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -31,7 +31,7 @@ export const getNextRankBar = (
   percentage: number,
   color: string,
 ): string => {
-  const maxWidht = 80;
+  const maxWidth = 80;
   return `
     <style>
     @keyframes ${title}RankAnimation {
@@ -39,7 +39,7 @@ export const getNextRankBar = (
         width: 0px;
       }
       to {
-        width: ${maxWidht * percentage}px;
+        width: ${maxWidth * percentage}px;
       }
     }
     #${title}-rank-progress{
@@ -50,7 +50,7 @@ export const getNextRankBar = (
       x="15"
       y="101"
       rx="1"
-      width="${maxWidht}"
+      width="${maxWidth}"
       height="3.2"
       opacity="0.3"
       fill="${color}"

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -2,7 +2,7 @@ import { RANK } from "./utils.ts";
 import { Theme } from "./theme.ts";
 
 const leafIcon = (laurel: string): string => {
-  return  `<svg xmlns="http://www.w3.org/2000/svg" version="1.0" width="90pt" height="90pt" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+  return  `<svg xmlns="http://www.w3.org/2000/svg" width="90pt" height="90pt" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
 <metadata>
 Created by potrace 1.15, written by Peter Selinger 2001-2017
 </metadata>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,11 +38,11 @@ export class CustomURLSearchParams extends URLSearchParams {
 }
 
 export function parseParams(req: ServerRequest): CustomURLSearchParams {
-  const splitedURL = req.url.split("?");
-  if (splitedURL.length < 2) {
+  const splittedURL = req.url.split("?");
+  if (splittedURL.length < 2) {
     return new CustomURLSearchParams();
   }
-  return new CustomURLSearchParams(splitedURL[1]);
+  return new CustomURLSearchParams(splittedURL[1]);
 }
 
 export function abridgeScore(score: number): string {


### PR DESCRIPTION
SVG's version attribute is deprecated: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/version
#canceled: An import path cannot end with a '.ts' extension.
Fixed typos.
Added .idea folder (WebStorm) to .gitignore.