### PR TITLE
Add better look on Github dark theme

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,6 @@
 export const COLORS: {[name: string]: Theme} = {
   default: {
-    BACKGROUND: "transparent",
+    BACKGROUND: "#FFF",
     TITLE: "#000",
     ICON_CIRCLE: "#FFF",
     TEXT: "#666",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,6 @@
 export const COLORS: {[name: string]: Theme} = {
   default: {
-    BACKGROUND: "#FFF",
+    BACKGROUND: "transparent",
     TITLE: "#000",
     ICON_CIRCLE: "#FFF",
     TEXT: "#666",


### PR DESCRIPTION
# Github Dark Theme support

Just added transparent as background color of default profile trophy theme.
So it is dark in github dark theme and light in default github theme.