### PR TITLE
fix: iterate through repository language nodes

### DIFF
--- a/src/github_api_client.ts
+++ b/src/github_api_client.ts
@@ -85,8 +85,12 @@ export class GithubAPIClient {
 
     const languages = new Set<string>();
     userData.repositories.nodes.forEach((node: Repository) => {
-      if (node.languages.nodes[0] != undefined) {
-        languages.add(node.languages.nodes[0].name);
+      if (node.languages.nodes != undefined) {
+        node.languages.nodes.forEach((node: Language) => {
+          if (node != undefined) {
+            languages.add(node.name)
+          }
+        }
       }
     });
     const durationTime = new Date().getTime() -


### PR DESCRIPTION
Just made a little oopsie I forgot to actually count the language after getting more from the API. Iterating (`.forEach(...)`) through each repository's language nodes should fix the problem.