### PR TITLE
feat(organization): multiple additions to trophy

### DIFF
--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -187,13 +187,14 @@ export class MultipleOrganizationsTrophy extends Trophy{
     const rankConditions = [
       new RankCondition(
         RANK.SECRET,
-        "Multiple Jobs",
-        2,
+        // or if this doesn't render well: "Factorum"
+        "Jack of all Trades",
+        3,
       ),
     ];
     super(score, rankConditions);
     this.title = "Organizations";
-    this.filterTitles = ["Organizations"];
+    this.filterTitles = ["Organizations", "Orgs", "Teams"];
     this.hidden = true;
   }
 }


### PR DESCRIPTION
Kewl new trophy! I have a few ideas:
The title "Multiple Jobs" seems a bit... normal if you get what I mean.
Can we try "Jack of all Trades", which sounds interesting. One problem is it might be too big, so we could go with "Factotum" which basically means the same thing (someone who is skilled in/does multiple fields/jobs) and sounds really awesome as well.

In addition I raised the requirement to three organizations because two organizations is a little too easy.

I also added the "Orgs" and "Teams" aliases to the filterTitles so that the size of the url can be smaller.

Let me know what you think :)