### PR TITLE
stat trophies is more clear than trophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="140" src="https://user-images.githubusercontent.com/6661165/91657958-61b4fd00-eb00-11ea-9def-dc7ef5367e34.png" />  
   <h2 align="center">Github Profile Trophy</h2>
-  <p align="center">🏆 Add dynamically generated GitHub Trophy on your readme</p>
+  <p align="center">🏆 Add dynamically generated GitHub Stat Trophies on your readme</p>
 </p>
 <p align="center">
   <a href="https://github.com/ryo-ma/github-profile-trophy/issues">


### PR DESCRIPTION
The README says "GitHub Trophy" but "GitHub Stat Trophies" is clearer.