### PR TITLE
grammar correction

### DIFF
--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -229,7 +229,7 @@ export class TotalStarTrophy extends Trophy {
       ),
       new RankCondition(
         RANK.A,
-        "You are Star",
+        "You are a Star",
         30,
       ),
       new RankCondition(


### PR DESCRIPTION
Changed "You are Star" to "You are a Star". The noun phrase "star" was missing a determiner before it.