### PR TITLE
Provide descriptive error when `username` missing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { GithubAPIClient } from "./src/github_api_client.ts";
 import { Card } from "./src/card.ts";
 import { CONSTANTS, parseParams } from "./src/utils.ts";
 import { COLORS, Theme } from "./src/theme.ts";
+import { Error400 } from './src/error_page.ts';
 import "https://deno.land/x/dotenv@v0.5.0/load.ts";
 
 const client = new GithubAPIClient();
@@ -41,10 +42,14 @@ export default async (req: ServerRequest) => {
   ).map((r) => r.trim());
 
   if (username === null) {
+    const [base] = req.url.split("?");
+    const error = new Error400(`<h2><code>username</code> is a required query parameter</h2>
+<p>The URL should look like <code>${base}?username=USERNAME</code>, where
+<code>USERNAME</code> is <em>your GitHub username.</em>`);
     req.respond(
       {
-        body: "Can not find a query parameter: username",
-        status: 404,
+        body: error.render(),
+        status: error.status,
         headers: new Headers({ "Content-Type": "text" }),
       },
     );

--- a/src/error_page.ts
+++ b/src/error_page.ts
@@ -1,0 +1,11 @@
+abstract class BaseError {
+  readonly status!: number;
+  constructor(readonly content?: string) {}
+  render(): string {
+    return `<!DOCTYPE html><html><body><h1>${this.status}</h1>${this.content ?? ''}</body></html>`;
+  }
+}
+
+export class Error400 extends BaseError {
+  readonly status = 400;
+}


### PR DESCRIPTION
After seeing issues like #124 and #72, I thought it would be useful if the error response was more descriptive.

I changed the error code from `404` to `400` since it's not a page that's missing, but that the user failed to make a proper request.

***

Apologies, but I can't seem to get `debug.ts` to run on my system.
```console
$ deno run --allow-net --allow-read --allow-env debug.ts
error: TS2339 [ERROR]: Property 'getIterator' does not exist on type 'ReadableStream<R>'.
  return res.readable.getIterator();
                      ~~~~~~~~~~~
    at https://deno.land/std@0.66.0/async/pool.ts:45:23
```

So I wasn't able to run server locally, and there might be some issues with this PR.