### PR TITLE
Support adaptive width (column=-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ https://github-profile-trophy.vercel.app/?username=ryo-ma&row=2&column=3
   <img width="330" src="https://user-images.githubusercontent.com/6661165/91659474-c07f7400-eb0a-11ea-84f2-eb6b42547829.png">
 </p>
 
+Adaptive column
+```
+https://github-profile-trophy.vercel.app/?username=ryo-ma&column=-1
+```
+
+You can set `columns` to `-1` to adapt the width to the number of trophys, the parameter `row` will be ignored.
+
 ## Apply theme
 
 Available themes.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Adaptive column
 https://github-profile-trophy.vercel.app/?username=ryo-ma&column=-1
 ```
 
-You can set `columns` to `-1` to adapt the width to the number of trophys, the parameter `row` will be ignored.
+You can set `columns` to `-1` to adapt the width to the number of trophies, the parameter `row` will be ignored.
 
 ## Apply theme
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/src/card.ts
+++ b/src/card.ts
@@ -38,6 +38,12 @@ export class Card {
 
     trophyList.sortByRank();
 
+    if (this.maxColumn == -1) {
+      this.maxColumn = trophyList.length;
+      this.width = this.panelSize * this.maxColumn +
+        this.marginWidth * (this.maxColumn - 1);
+    }
+
     const row = this.getRow(trophyList);
     this.height = this.getHeight(row);
 


### PR DESCRIPTION
Set the parameter `column` to `-1` to enable adaptive width, the width of the generated SVG will be adapted to the number of trophies. This is useful when you are adding a fixed-width center card to the profile.

![image](https://user-images.githubusercontent.com/23134847/161484940-9c75059a-e427-4aa3-9b77-b90685aa0c96.png)
Before

![image](https://user-images.githubusercontent.com/23134847/161484990-7a7c5ac8-ee38-49a5-b43a-e0e9c3087628.png)
After