### PR TITLE
Added Total Reviews Trophy

### DIFF
--- a/src/github_api_client.ts
+++ b/src/github_api_client.ts
@@ -38,6 +38,7 @@ export class GithubAPIClient {
             contributionsCollection {
               totalCommitContributions
               restrictedContributionsCount
+              totalPullRequestReviewContributions
             }
             organizations(first: 1) {
               totalCount

--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -216,6 +216,56 @@ export class OGAccountTrophy extends Trophy{
   }
 }
 
+export class TotalReviewsTrophy extends Trophy {
+  constructor(score: number) {
+    const rankConditions = [
+      new RankCondition(
+        RANK.SSS,
+        "God Reviewer",
+        70,
+      ),
+      new RankCondition(
+        RANK.SS,
+        "Deep Reviewer",
+        57,
+      ),
+      new RankCondition(
+        RANK.S,
+        "Super Reviewer",
+        45,
+      ),
+      new RankCondition(
+        RANK.AAA,
+        "Ultra Reviewer",
+        30,
+      ),
+      new RankCondition(
+        RANK.AA,
+        "Hyper Reviewer",
+        20,
+      ),
+      new RankCondition(
+        RANK.A,
+        "Active Reviewer",
+        8,
+      ),
+      new RankCondition(
+        RANK.B,
+        "Intermediate Reviewer",
+        3,
+      ),
+      new RankCondition(
+        RANK.C,
+        "New Reviewer",
+        1,
+      ),
+    ];
+    super(score, rankConditions);
+    this.title = "Reviews";
+    this.filterTitles = ["Review", "Reviews"];
+  }
+}
+
 export class TotalStarTrophy extends Trophy {
   constructor(score: number) {
     const rankConditions = [

--- a/src/trophy_list.ts
+++ b/src/trophy_list.ts
@@ -6,6 +6,7 @@ import {
   TotalIssueTrophy,
   TotalPullRequestTrophy,
   TotalRepositoryTrophy,
+  TotalReviewsTrophy,
   MultipleLangTrophy,
   LongTimeAccountTrophy,
   AncientAccountTrophy,
@@ -28,6 +29,7 @@ export class TrophyList {
       new TotalIssueTrophy(userInfo.totalIssues),
       new TotalPullRequestTrophy(userInfo.totalPullRequests),
       new TotalRepositoryTrophy(userInfo.totalRepositories),
+      new TotalReviewsTrophy(userInfo.totalReviews),
     );
     // Secret trophies
     this.trophies.push(

--- a/src/user_info.ts
+++ b/src/user_info.ts
@@ -31,6 +31,7 @@ export type GitHubUserActivity = {
   contributionsCollection: {
     totalCommitContributions: number;
     restrictedContributionsCount: number;
+    totalPullRequestReviewContributions: number;
   };
   organizations: {
     totalCount: number;
@@ -45,6 +46,7 @@ export class UserInfo {
   public readonly totalIssues: number;
   public readonly totalOrganizations: number;
   public readonly totalPullRequests: number;
+  public readonly totalReviews: number;
   public readonly totalStargazers: number;
   public readonly totalRepositories: number;
   public readonly languageCount: number;
@@ -94,6 +96,7 @@ export class UserInfo {
     this.totalIssues = userIssue.openIssues.totalCount + userIssue.closedIssues.totalCount;
     this.totalOrganizations = userActivity.organizations.totalCount;
     this.totalPullRequests = userPullRequest.pullRequests.totalCount;
+    this.totalReviews = userActivity.contributionsCollection.totalPullRequestReviewContributions;
     this.totalStargazers = totalStargazers;
     this.totalRepositories = userRepository.repositories.totalCount;
     this.languageCount = languages.size;


### PR DESCRIPTION
_Addition_: Trophy named *Reviews*
_Conditioning_: Based on the Number of Code Reviews
_Points Calculation_: Number of Code Reviews
_Rank Updates_: Linear

The output of `deno lint --unstable`:
![Screenshot from 2023-05-16 13-11-11](https://github.com/ryo-ma/github-profile-trophy/assets/43399374/e625b275-762a-4e2a-b903-32f6bea2bffa)

_FYI_: Based on an issue too - https://github.com/ryo-ma/github-profile-trophy/issues/177

Hope I can get this PR merged. (Please let me know if you want any changes in the rank titles or conditionals for the ranks)
~ @bhavberi