### PR TITLE
Updated Joined 2020 trophy to this Joined this year trophy

### DIFF
--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -135,7 +135,7 @@ export class AllSuperRankTrophy extends Trophy{
     this.hidden = true;
   }
 }
-export class Joined2020Trophy extends Trophy{
+export class JoinedThisYearTrophy extends Trophy{
   constructor(score: number){
     const rankConditions = [
       new RankCondition(
@@ -145,9 +145,9 @@ export class Joined2020Trophy extends Trophy{
       ),
     ];
     super(score, rankConditions);
-    this.title = "Joined2020";
-    this.filterTitles = ["Joined2020"];
-    this.bottomMessage = "Joined 2020"
+    this.title = "New Joinee";
+    this.filterTitles = ["New", "JoinedThisYear"];
+    this.bottomMessage = `Joined ${new Date().getUTCFullYear()}`
     this.hidden = true;
   }
 }

--- a/src/trophy_list.ts
+++ b/src/trophy_list.ts
@@ -10,7 +10,7 @@ import {
   LongTimeAccountTrophy,
   AncientAccountTrophy,
   OGAccountTrophy,
-  Joined2020Trophy,
+  JoinedThisYearTrophy,
   AllSuperRankTrophy,
   MultipleOrganizationsTrophy,
 } from "./trophy.ts";
@@ -36,7 +36,7 @@ export class TrophyList {
       new LongTimeAccountTrophy(userInfo.durationYear),
       new AncientAccountTrophy(userInfo.ancientAccount),
       new OGAccountTrophy(userInfo.ogAccount),
-      new Joined2020Trophy(userInfo.joined2020),
+      new JoinedThisYearTrophy(userInfo.joinedThisYear),
       new MultipleOrganizationsTrophy(userInfo.totalOrganizations),
     );
   }

--- a/src/user_info.ts
+++ b/src/user_info.ts
@@ -50,7 +50,7 @@ export class UserInfo {
   public readonly languageCount: number;
   public readonly durationYear: number;
   public readonly ancientAccount: number;
-  public readonly joined2020: number;
+  public readonly joinedThisYear: number;
   public readonly ogAccount: number;
   constructor(
     userActivity: GitHubUserActivity,
@@ -83,7 +83,7 @@ export class UserInfo {
     const durationYear = new Date(durationTime).getUTCFullYear() - 1970;
     const ancientAccount =
       new Date(userActivity.createdAt).getFullYear() <= 2010 ? 1 : 0;
-    const joined2020 = new Date(userActivity.createdAt).getFullYear() == 2020
+    const joinedThisYear = new Date(userActivity.createdAt).getFullYear() == new Date().getUTCFullYear()
       ? 1
       : 0;
     const ogAccount =
@@ -99,7 +99,7 @@ export class UserInfo {
     this.languageCount = languages.size;
     this.durationYear = durationYear;
     this.ancientAccount = ancientAccount;
-    this.joined2020 = joined2020;
+    this.joinedThisYear = joinedThisYear;
     this.ogAccount = ogAccount;
   }
 }


### PR DESCRIPTION
_Updation_: Trophy named *Joined 2020* -> Trophy named "New Joinee"
_Conditioning_: If the user has joined this current year

The output of `deno lint --unstable`:
![Screenshot from 2023-05-16 13-11-11](https://github.com/ryo-ma/github-profile-trophy/assets/43399374/e625b275-762a-4e2a-b903-32f6bea2bffa)

_FYI_: Based on a comment too - https://github.com/ryo-ma/github-profile-trophy/pull/99#pullrequestreview-911013175

Hope I can get this PR merged. (Please let me know if you want any changes in the rank titles or conditionals for the ranks)
~ @bhavberi