### PR TITLE
Update trophy.ts with spelling correction of "Grandmaster"

### DIFF
--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -277,7 +277,7 @@ export class AccountDurationTrophy extends Trophy {
       ),
       new RankCondition(
         RANK.SS,
-        "GranMaster",
+        "Grandmaster",
         55, // 15 years
       ),
       new RankCondition(


### PR DESCRIPTION
I found that there was a spelling mistake, so I thought I would correct it (it would look better now on someone's profile).

PS: I did not make this PR for spam, I just happened to find the mistake, so thought to correct it.