### PR TITLE
Add license info and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,10 @@ https://github-profile-trophy.vercel.app/?username=ryo-ma&no-frame=true
 
 Check [CONTRIBUTING.md](./CONTRIBUTING.md) for more details.
 
+# License
+
+This product is licensed under the [MIT License](https://github.com/ryo-ma/github-profile-trophy/blob/master/LICENSE).
+
 # Testing
 
 ```bash


### PR DESCRIPTION
Some people may overlook the license, and it is also standard for most major projects to have their license clearly outlined in the ReadME e.g. with Google.