### PR TITLE
Change text of the points, and hide extra info for some special trophies

### DIFF
--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -16,8 +16,10 @@ export class Trophy {
   topMessage = "Unknown";
   bottomMessage = "0";
   title = "";
+  criterion = "pt";
   filterTitles: Array<string> = [];
   hidden = false;
+  hideinfo = false;
   constructor(
     private score: number,
     private rankConditions: Array<RankCondition>,
@@ -97,8 +99,8 @@ export class Trophy {
           ${getTrophyIcon(theme, this.rank)}
           <text x="50%" y="18" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="13" fill="${SECONDARY}">${this.title}</text>
           <text x="50%" y="85" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10.5" fill="${TEXT}">${this.topMessage}</text>
-          <text x="50%" y="97" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10" fill="${TEXT}">${this.bottomMessage}</text>
-          ${nextRankBar}
+            ${this.hideinfo ? '' : `<text x="50%" y="97" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10" fill="${TEXT}">${this.bottomMessage} ${this.criterion}</text>`}
+            ${this.hideinfo ? '' : nextRankBar}
         </svg>
         `;
   }
@@ -117,6 +119,7 @@ export class MultipleLangTrophy extends Trophy {
     this.title = "MultiLanguage";
     this.filterTitles = ["MultipleLang", "MultiLanguage"];
     this.hidden = true;
+    this.criterion = "Lang/s";
   }
 }
 
@@ -134,6 +137,7 @@ export class AllSuperRankTrophy extends Trophy {
     this.filterTitles = ["AllSuperRank"];
     this.bottomMessage = "All S Rank";
     this.hidden = true;
+    this.hideinfo = true;
   }
 }
 export class Joined2020Trophy extends Trophy {
@@ -150,6 +154,7 @@ export class Joined2020Trophy extends Trophy {
     this.filterTitles = ["Joined2020"];
     this.bottomMessage = "Joined 2020";
     this.hidden = true;
+    this.hideinfo = true;
   }
 }
 export class AncientAccountTrophy extends Trophy {
@@ -166,6 +171,7 @@ export class AncientAccountTrophy extends Trophy {
     this.filterTitles = ["AncientUser"];
     this.bottomMessage = "Before 2010";
     this.hidden = true;
+    this.hideinfo = true;
   }
 }
 export class LongTimeAccountTrophy extends Trophy {
@@ -214,6 +220,7 @@ export class OGAccountTrophy extends Trophy {
     this.filterTitles = ["OGUser"];
     this.bottomMessage = "Joined 2008";
     this.hidden = true;
+    this.hideinfo = true;
   }
 }
 
@@ -264,6 +271,7 @@ export class TotalReviewsTrophy extends Trophy {
     super(score, rankConditions);
     this.title = "Reviews";
     this.filterTitles = ["Review", "Reviews"];
+    this.criterion = "Review/s";
   }
 }
 
@@ -365,6 +373,7 @@ export class TotalStarTrophy extends Trophy {
     super(score, rankConditions);
     this.title = "Stars";
     this.filterTitles = ["Star", "Stars"];
+    this.criterion = "Star/s";
   }
 }
 
@@ -415,6 +424,7 @@ export class TotalCommitTrophy extends Trophy {
     super(score, rankConditions);
     this.title = "Commits";
     this.filterTitles = ["Commit", "Commits"];
+    this.criterion = "Commit/s";
   }
 }
 
@@ -465,6 +475,7 @@ export class TotalFollowerTrophy extends Trophy {
     super(score, rankConditions);
     this.title = "Followers";
     this.filterTitles = ["Follower", "Followers"];
+    this.criterion = "Follower/s";
   }
 }
 
@@ -515,6 +526,7 @@ export class TotalIssueTrophy extends Trophy {
     super(score, rankConditions);
     this.title = "Issues";
     this.filterTitles = ["Issue", "Issues"];
+    this.criterion = "Issue/s";
   }
 }
 
@@ -565,6 +577,7 @@ export class TotalPullRequestTrophy extends Trophy {
     super(score, rankConditions);
     this.title = "PullRequest";
     this.filterTitles = ["PR", "PullRequest", "Pulls", "Puller"];
+    this.criterion = "PR/s";
   }
 }
 
@@ -615,5 +628,6 @@ export class TotalRepositoryTrophy extends Trophy {
     super(score, rankConditions);
     this.title = "Repositories";
     this.filterTitles = ["Repo", "Repository", "Repositories"];
+    this.criterion = "Repo/s";
   }
 }

--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -99,8 +99,12 @@ export class Trophy {
           ${getTrophyIcon(theme, this.rank)}
           <text x="50%" y="18" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="13" fill="${SECONDARY}">${this.title}</text>
           <text x="50%" y="85" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10.5" fill="${TEXT}">${this.topMessage}</text>
-            ${this.hideinfo ? '' : `<text x="50%" y="97" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10" fill="${TEXT}">${this.bottomMessage} ${this.criterion}</text>`}
-            ${this.hideinfo ? '' : nextRankBar}
+            ${
+      this.hideinfo
+        ? ""
+        : `<text x="50%" y="97" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10" fill="${TEXT}">${this.bottomMessage} ${this.criterion}</text>`
+    }
+            ${this.hideinfo ? "" : nextRankBar}
         </svg>
         `;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,12 +45,12 @@ export function parseParams(req: Request): CustomURLSearchParams {
 
 export function abridgeScore(score: number): string {
   if (Math.abs(score) < 1) {
-    return "0pt";
+    return "0";
   }
   if (Math.abs(score) > 999) {
-    return (Math.sign(score) * (Math.abs(score) / 1000)).toFixed(1) + "kpt";
+    return (Math.sign(score) * (Math.abs(score) / 1000)).toFixed(1) + "k";
   }
-  return (Math.sign(score) * Math.abs(score)).toString() + "pt";
+  return (Math.sign(score) * Math.abs(score)).toString();
 }
 
 const HOUR_IN_MILLISECONDS = 60 * 60 * 1000;


### PR DESCRIPTION
- Changed the text `pt` to meaningful for different trophies. The default text is still `pt`. (Related to issue https://github.com/ryo-ma/github-profile-trophy/issues/112)
- Hide the points text and the rank bar for special trophies, which are, in a sense, binary to get. (For Example - Joined2020Trophy, where the points does not make sense)