### PR TITLE
Update contributing guide with correct formatting cmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,10 @@ look forward to seeing what you come up with!
 deno task lint
 ```
 
-### 2. Run deno fmt
+### 2. Run deno format
 
 ```sh
-deno task fmt
+deno task format
 ```
 
 ### 3. Run deno test


### PR DESCRIPTION
The deno.json task is named `format`, however in the contributing guide it says to run `deno task fmt`. This pull request updates this to `deno task format`.