### PR TITLE
"Experience" trophy score threshold adjustments

### DIFF
--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -273,7 +273,7 @@ export class AccountDurationTrophy extends Trophy {
       new RankCondition(
         RANK.SSS,
         "Seasoned Veteran",
-        70, // 20 years
+        73, // 20 years
       ),
       new RankCondition(
         RANK.SS,
@@ -283,7 +283,7 @@ export class AccountDurationTrophy extends Trophy {
       new RankCondition(
         RANK.S,
         "Master Dev",
-        40, // 10 years
+        37, // 10 years
       ),
       new RankCondition(
         RANK.AAA,


### PR DESCRIPTION
Adjusted two of the score thresholds for the `AccountDurationTrophy` to be more accurate estimates of the durations in the code comments.

"Seasoned Veteran": 70 changed to 73 (20 years)
"Master Dev": 40 changed to 37 (10 years)