### PR TITLE
Include a query where the user can exclude trophies based on title

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ If you want to specify multiple titles.
 https://github-profile-trophy.vercel.app/?username=ryo-ma&title=Stars,Followers
 ```
 
+You can also exclude the trophies you don't want to display.
+
+```
+https://github-profile-trophy.vercel.app/?username=ryo-ma&title=-Issues,-Commits
+```
+
 ## Filter by ranks
 
 You can filter the display by specifying the ranks.\

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ https://github-profile-trophy.vercel.app/?username=ryo-ma&title=Stars,Followers
 You can also exclude the trophies you don't want to display.
 
 ```
-https://github-profile-trophy.vercel.app/?username=ryo-ma&title=-Issues,-Commits
+https://github-profile-trophy.vercel.app/?username=ryo-ma&title=-Stars,-Followers
 ```
 
 ## Filter by ranks

--- a/src/card.ts
+++ b/src/card.ts
@@ -29,7 +29,11 @@ export class Card {
     trophyList.filterByHidden();
 
     if (this.titles.length != 0) {
-      trophyList.filterByTitles(this.titles);
+      const includeTitles = this.titles.filter(title => !title.startsWith("-"));
+      if (includeTitles.length > 0) {
+        trophyList.filterByTitles(includeTitles);
+      }
+      trophyList.filterByExclusionTitles(this.titles);
     }
 
     if (this.ranks.length != 0) {

--- a/src/card.ts
+++ b/src/card.ts
@@ -29,7 +29,9 @@ export class Card {
     trophyList.filterByHidden();
 
     if (this.titles.length != 0) {
-      const includeTitles = this.titles.filter(title => !title.startsWith("-"));
+      const includeTitles = this.titles.filter((title) =>
+        !title.startsWith("-")
+      );
       if (includeTitles.length > 0) {
         trophyList.filterByTitles(includeTitles);
       }

--- a/src/trophy_list.ts
+++ b/src/trophy_list.ts
@@ -76,6 +76,12 @@ export class TrophyList {
       ranks.includes(trophy.rank)
     );
   }
+  filterByExclusionTitles(titles: Array<string>) {
+    const excludeTitles = titles.filter(title => title.startsWith("-")).map(title => title.substring(1));
+    if (excludeTitles.length > 0) {
+      this.trophies = this.trophies.filter(trophy => !excludeTitles.includes(trophy.title));
+    }
+  }
   sortByRank() {
     this.trophies = this.trophies.sort((a: Trophy, b: Trophy) =>
       RANK_ORDER.indexOf(a.rank) - RANK_ORDER.indexOf(b.rank)

--- a/src/trophy_list.ts
+++ b/src/trophy_list.ts
@@ -77,9 +77,13 @@ export class TrophyList {
     );
   }
   filterByExclusionTitles(titles: Array<string>) {
-    const excludeTitles = titles.filter(title => title.startsWith("-")).map(title => title.substring(1));
+    const excludeTitles = titles.filter((title) => title.startsWith("-")).map(
+      (title) => title.substring(1),
+    );
     if (excludeTitles.length > 0) {
-      this.trophies = this.trophies.filter(trophy => !excludeTitles.includes(trophy.title));
+      this.trophies = this.trophies.filter((trophy) =>
+        !excludeTitles.includes(trophy.title)
+      );
     }
   }
   sortByRank() {


### PR DESCRIPTION
This is my first time contributing to this repository.

This pull request adds a feature which helps the user exclude any trophy (or multiple trophies) they don't want to display by title.

For example,

```
https://github-profile-trophy.vercel.app/?username=ryo-ma&title=-Stars
```

This would exclude the trophy with the title Stars.

```
https://github-profile-trophy.vercel.app/?username=ryo-ma&title=-Stars,-Followers
```

This would exclude the trophies with the title Stars and Followers.

This is similar to excluding trophies based on rank.

This pull request also addresses what might be the primary concern of the author in issue #272.

Also, I ran the following commands based off the [CONTRIBUTING.md](https://github.com/ryo-ma/github-profile-trophy/blob/master/CONTRIBUTING.md#what-to-do-before-contributing).

```sh
deno task lint
deno task format
deno task test
```  

`deno task test` gave the following output, and passed the 9 tests.

![image](https://github.com/ryo-ma/github-profile-trophy/assets/93064304/ee6a07cf-7947-40ff-b5bc-413441f75c5b)
