### PR TITLE
fix: typo in home page button

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -81,7 +81,7 @@ async function app(req: Request): Promise<Response> {
         <form action="https://github-profile-trophy.vercel.app/" method="get">
           <label for="username">GitHub Username</label>
           <input type="text" name="username" id="username" placeholder="Ex. gabriel-logan" required>
-          <button type="submit">Get Trophy&apos;s</button>
+          <button type="submit">Get Trophies</button>
         </form>
       </div>
       <script>


### PR DESCRIPTION
The button on the home page for getting the trophies says: **"Get Trophy's"**, which is not grammatically correct.