### PR TITLE
Update Vercel Runtime to Fix Serverless Function Deployment Error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "public": true,
   "functions": {
     "api/**/*.[jt]s": {
-      "runtime": "vercel-deno@3.0.4"
+      "runtime": "vercel-deno@3.1.0"
     }
   },
   "rewrites": [


### PR DESCRIPTION
### Description

Fix an issue where deploying serverless functions on Vercel with the outdated runtime `vercel-deno@3.0.4` results in an error. The error occurs due to the runtime being invalid for the functions specified.

The error encountered during deployment is:
```
Error: The following Serverless Functions contain an invalid "runtime":
- api/index (provided.al2). Learn More: https://vercel.com/guides/serverless-function-contains-invalid-runtime-error
```
### Changes Made
Updated the runtime from `vercel-deno@3.0.4` to `vercel-deno@3.1.0` in the Vercel configuration file.

### Impact
This change resolves the deployment error and ensures that the serverless functions are deployed correctly on Vercel without any runtime-related issues.

### Testing
The change was tested by redeploying the functions after the runtime update, and the deployment was successful without errors.