### PR TITLE
docs: fixed the issue of blue underline between hyperlinks & added some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 </div>
 <div align="center">
 
-  [![stargazers](https://img.shields.io/github/stars/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/stargazers)
-  [![forks](https://img.shields.io/github/forks/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/network/members)
-  [![issues](https://img.shields.io/github/issues/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/issues)
-  [![license](https://img.shields.io/github/license/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/blob/master/LICENSE)
-  [![share](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy)](https://twitter.com/intent/tweet?text=Add%20dynamically%20generated%20GitHub%20Trophy%20on%20your%20readme%0D%0A&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy)
+[![stargazers](https://img.shields.io/github/stars/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/stargazers)
+[![forks](https://img.shields.io/github/forks/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/network/members)
+[![issues](https://img.shields.io/github/issues/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/issues)
+[![license](https://img.shields.io/github/license/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/blob/master/LICENSE)
+[![share](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy)](https://twitter.com/intent/tweet?text=Add%20dynamically%20generated%20GitHub%20Trophy%20on%20your%20readme%0D%0A&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy)
 
 </div>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,26 +1,16 @@
 <div align="center">
   <img width="140" src="https://user-images.githubusercontent.com/6661165/91657958-61b4fd00-eb00-11ea-9def-dc7ef5367e34.png"  alt="GitHub Profile Trophy"/>
   <h2 align="center">GitHub Profile Trophy</h2>
-  <p align="center">🏆 Add dynamically generated GitHub Stat Trophies on your readme</p>
+  <p align="center">🏆 Add dynamically generated GitHub Stat Trophies on your README</p>
 </div>
 <div align="center">
-  <a href="https://github.com/ryo-ma/github-profile-trophy/issues">
-    <img src="https://img.shields.io/github/issues/ryo-ma/github-profile-trophy" alt="Issues"/>
-  </a>
-  <a href="https://github.com/ryo-ma/github-profile-trophy/network/members">
-    <img src="https://img.shields.io/github/forks/ryo-ma/github-profile-trophy" alt="Forks"/>
-  </a>
-  <a href="https://github.com/ryo-ma/github-profile-trophy/stargazers">
-    <img src="https://img.shields.io/github/stars/ryo-ma/github-profile-trophy" alt="Stargazers"/>
-  </a>
-    <a href="https://github.com/ryo-ma/github-profile-trophy/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/ryo-ma/github-profile-trophy" alt="License"/>
-  </a>
-</div>
-<div align="center">
-    <a href="https://twitter.com/intent/tweet?text=Add%20dynamically%20generated%20GitHub%20Trophy%20on%20your%20readme%0D%0A&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy">
-    <img src="https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy" alt="Share"/>
-  </a>
+
+  [![stargazers](https://img.shields.io/github/stars/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/stargazers)
+  [![forks](https://img.shields.io/github/forks/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/network/members)
+  [![issues](https://img.shields.io/github/issues/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/issues)
+  [![license](https://img.shields.io/github/license/ryo-ma/github-profile-trophy)](https://github.com/ryo-ma/github-profile-trophy/blob/master/LICENSE)
+  [![share](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy)](https://twitter.com/intent/tweet?text=Add%20dynamically%20generated%20GitHub%20Trophy%20on%20your%20readme%0D%0A&url=https%3A%2F%2Fgithub.com%2Fryo-ma%2Fgithub-profile-trophy)
+
 </div>
 <p align="center">
   You can use this service for free. I'm looking for sponsors to help us keep up with this service❤️
@@ -74,8 +64,7 @@ Ranks are `SSS` `SS` `S` `AAA` `AA` `A` `B` `C` `UNKNOWN` `SECRET`.
 
 ## Secret Rank
 
-The acquisition condition is secret, but you can know the condition by reading
-this code.
+The acquisition condition is secret, but you can see this.
 
 <p align="center">
   <img width="110" src="https://github.com/user-attachments/assets/40461f38-a317-431c-93d2-a56c2e803cf3" />
@@ -126,6 +115,10 @@ If you want to specify multiple titles.
 https://github-profile-trophy.vercel.app/?username=ryo-ma&title=Stars,Followers
 ```
 
+<p align="center">
+  <img width="220" src="https://github.com/user-attachments/assets/3b8a1c8b-afcd-49dc-ab18-a439d5c36a83">
+</p>
+
 You can also exclude the trophies you don't want to display.
 
 ```
@@ -150,6 +143,10 @@ If you want to specify multiple ranks.
 ```
 https://github-profile-trophy.vercel.app/?username=ryo-ma&rank=S,AAA
 ```
+
+<p align="center">
+  <img width="220" src="https://github.com/user-attachments/assets/0c2ffca8-4b03-4d46-b1d7-4e1eb6702f68">
+</p>
 
 You can also exclude ranks.
 
@@ -483,6 +480,10 @@ You can put a margin in the height between trophies.\
 https://github-profile-trophy.vercel.app/?username=ryo-ma&margin-h=15
 ```
 
+<p align="center">
+  <img width="110" height="330" src="https://github.com/user-attachments/assets/233dee5b-4491-46cc-884a-39d0aa928752">
+</p>
+
 ## Example layout
 
 ```
@@ -508,7 +509,6 @@ https://github-profile-trophy.vercel.app/?username=ryo-ma&no-bg=true
 </p>
 
 ## Hide frames
-
 
 You can hide the frames around the trophies.\
 `Available value: boolean type (true or false)`\


### PR DESCRIPTION
1. The reason for the blue underline between hyperlinks is that the<img>tag in HTML automatically generates a blue underline, and adjacent hyperlinks are automatically connected. The solution is to use markdown to insert images.
2. Rearranged small tags such as star and forks in logical order.
3. Added several example images.
4. Fixed some statement  and format errors.