### PR TITLE
Fix async attribute error in script tag

### DIFF
--- a/src/error_page.ts
+++ b/src/error_page.ts
@@ -102,7 +102,7 @@ abstract class BaseError {
           }
         }
       </style>
-      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7387527627218970" crossorigin="anonymous"></script>
+      <script async="async" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7387527627218970" crossorigin="anonymous"></script>
     </head>
     <body>
       <h1 style="text-align: center;">${this.message}</h1>


### PR DESCRIPTION
Bug Fix
Fixed XML parsing error caused by invalid async attribute in script tag.
     
Problem
The script tag in error_page.ts had `async` attribute without a value, causing: "Specification mandates value for attribute async"