### PR TITLE
fix: update deno tasks to use main.ts instead of missing debug.ts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
-    "start": "deno run -A debug.ts",
-    "debug": "deno run --inspect-brk -A debug.ts",
+    "start": "deno run -A main.ts",
+    "debug": "deno run --inspect-brk -A main.ts",
     "format": "deno fmt",
     "lint": "deno lint",
     "test": "ENV_TYPE=test deno test --allow-env"


### PR DESCRIPTION
Currently, `deno.json` references `debug.ts`, but that file no longer exists.
This causes `deno task start` to fail with a `Module not found` error.

This PR updates the `start` and `debug` tasks in `deno.json` to use `main.ts`,
which is the current entry point of the project.
