### PR TITLE
Add additional load balancing endpoint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ These are endpoints provided by volunteers. Please use these in moderation.
   by [hongbo-wei](https://github.com/hongbo-wei)
 - [https://github-profile-trophy-kannan.vercel.app](https://github-profile-trophy-kannan.vercel.app)
   by [kann4n](https://github.com/kann4n)
+- [https://trophy.ryglcloud.net](https://trophy.ryglcloud.net)
+  by [PracticalRyan](https://github.com/PracticalRyan)
 
 # Quick Start
 


### PR DESCRIPTION
This PR adds a new community self-hosted mirror hosted in Singapore to the documentation.

I currently have a VPS that extends my home-lab and would like to contribute some compute.

### Instance Details
* **URL:** `https://trophy.ryglcloud.net`
* **Infrastructure:** Docker (OVH Cloud VPS)
* **Cache:** Persistent Redis (Should better prevent GitHub rate limits compared to serverless instances)
* **Uptime:** [Monitored 24/7 (Live Status Page)](https://status.ryglcloud.net)

### Changes
* [x] Added `https://trophy.ryglcloud.net` to the list of available instances in `README.md`.