### PR TITLE
feat(ui): redesign landing page and refine trophy SVG aesthetics

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -44,49 +44,7 @@ async function app(req: Request): Promise<Response> {
   const themeParam: string = params.getStringValue("theme", "default");
   if (username === null) {
     const [base] = req.url.split("?");
-    const error = new Error400(
-      `<section>
-      <div>
-        <h2>"username" is a required query parameter</h2>
-        <p>The URL should look like
-        <div>
-          <p id="base-show">${base}?username=USERNAME</p>
-          <button>Copy Base Url</button>
-          <span id="temporary-span"></span>
-        </div>where
-        <code>USERNAME</code> is <em>your GitHub username.</em>
-      </div>
-      <div>
-        <h2>You can use this form: </h2>
-        <p>Enter your username and click "Get Trophies"</p>
-        <form action="${base}" method="get">
-          <label for="username">GitHub Username</label>
-          <input type="text" name="username" id="username" placeholder="Ex. gabriel-logan" required>
-          <label for="theme">Theme (Optional)</label>
-          <input type="text" name="theme" id="theme" placeholder="Ex. onedark" value="light">
-          <text>
-            See all the available themes
-            <a href="https://github.com/ryo-ma/github-profile-trophy?tab=readme-ov-file#apply-theme" target="_blank">here</a>
-          </text>
-          <br>
-          <button type="submit">Get Trophies</button>
-        </form>
-      </div>
-      <script>
-        const button = document.querySelector("button");
-        const input = document.querySelector("input");
-        const temporarySpan = document.querySelector("#temporary-span");
-
-        button.addEventListener("click", () => {
-          navigator.clipboard.writeText(document.querySelector("#base-show").textContent);
-          temporarySpan.textContent = "Copied!";
-          setTimeout(() => {
-            temporarySpan.textContent = "";
-          }, 1500);
-        });
-      </script>
-    </section>`,
-    );
+    const error = new Error400(base);
     return new Response(
       error.render(),
       {

--- a/src/Services/GithubApiService.ts
+++ b/src/Services/GithubApiService.ts
@@ -72,7 +72,14 @@ export class GithubApiService extends GithubRepository {
         pullRequest.status,
       ];
 
-      if (status.includes("rejected")) {
+      const values = [
+        repository.status === "fulfilled" ? repository.value : null,
+        activity.status === "fulfilled" ? activity.value : null,
+        issue.status === "fulfilled" ? issue.value : null,
+        pullRequest.status === "fulfilled" ? pullRequest.value : null,
+      ];
+
+      if (status.includes("rejected") || values.some((v) => v instanceof ServiceError)) {
         Logger.error(`Can not find a user with username:' ${username}'`);
         return new ServiceError("Not found", EServiceKindError.NOT_FOUND);
       }

--- a/src/error_page.ts
+++ b/src/error_page.ts
@@ -1,130 +1,353 @@
 abstract class BaseError {
   readonly status!: number;
   readonly message!: string;
-  constructor(readonly content?: string) {}
-  render() {
+
+  render(): string {
     return this.renderPage();
   }
 
-  private renderPage() {
+  protected renderPage(): string {
     return `<!DOCTYPE html>
-    <html lang="en"><head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>GitHub Profile Trophy</title>
-      <meta name="description" content="🏆 Add dynamically generated GitHub Stat Trophies on your readme">
-      <style>
-        body {
-          font-family: Arial, sans-serif;
-          margin: 0;
-          padding: 0;
-          background-color: #f4f4f4;
-        }
-        h1,
-        h2 {
-          color: #333;
-        }
-        p {
-          color: #666;
-        }
-        #back-link {
-          display: flex;
-          justify-content: center;
-          text-decoration: none;
-        }
-        #back-link:hover {
-          text-decoration: underline;
-        }
-        section {
-          width: 80%;
-          margin: 0 auto;
-          padding: 20px;
-        }
-        div {
-          background-color: #fff;
-          border-radius: 5px;
-          padding: 20px;
-          margin-bottom: 20px;
-          box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
-        }
-        form {
-          display: flex;
-          flex-direction: column;
-        }
-        label {
-          margin-bottom: 10px;
-        }
-        input {
-          padding: 12px;
-          margin-bottom: 20px;
-          border-radius: 5px;
-          border: 1px solid #ddd;
-        }
-        button {
-          padding: 10px 20px;
-          background-color: #333;
-          color: #fff;
-          border: none;
-          border-radius: 5px;
-          cursor: pointer;
-        }
-        #base-show {
-          font-size: 16px;
-          color: #333;
-          background-color: #f4f4f4;
-          padding: 10px;
-          border-radius: 5px;
-          text-align: center;
-          margin: 10px 0;
-        }
-        button:hover {
-          background-color: #444;
-        }
-        @media (max-width: 768px) {
-          #base-show {
-            font-size: 14px;
-          }
-        }
-        @media (max-width: 480px) {
-          #base-show {
-            font-size: 8px;
-          }
-        }
-        @media (min-width: 768px) {
-          section {
-            width: 60%;
-          }
-        }
-        @media (min-width: 1024px) {
-          section {
-            width: 50%;
-          }
-        }
-      </style>
-    </head>
-    <body>
-      <h1 style="text-align: center;">${this.status} - ${this.message}</h1>
-      <p style="text-align: center;">${this.content ?? ""}</p>
-      ${
-      this.content &&
-      '<a id="back-link" href="/">Go back</a>'
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${this.status} — GitHub Profile Trophy</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      background: #f9f9f8;
+      color: #18181b;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 48px 24px;
     }
-    </body>
-    </html>`;
+    .eyebrow {
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #a1a1aa;
+      margin-bottom: 24px;
+    }
+    .code {
+      font-size: 80px;
+      font-weight: 200;
+      letter-spacing: -0.04em;
+      line-height: 1;
+      color: #18181b;
+      margin-bottom: 16px;
+    }
+    .label {
+      font-size: 15px;
+      color: #71717a;
+      margin-bottom: 8px;
+    }
+    .detail {
+      font-size: 13px;
+      color: #a1a1aa;
+      margin-bottom: 40px;
+    }
+    a.back {
+      display: inline-block;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #71717a;
+      text-decoration: none;
+      border-bottom: 1px solid #e4e4e7;
+      padding-bottom: 2px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    a.back:hover { color: #18181b; border-color: #18181b; }
+  </style>
+</head>
+<body>
+  <p class="eyebrow">GitHub Profile Trophy</p>
+  <h1 class="code">${this.status}</h1>
+  <p class="label">${this.message}</p>
+  ${this.renderContent()}
+  <a class="back" href="/">Return home</a>
+</body>
+</html>`;
+  }
+
+  protected renderContent(): string {
+    return "";
   }
 }
 
 export class Error400 extends BaseError {
   readonly status = 400;
   readonly message = "Bad Request";
+
+  constructor(private readonly baseUrl = "/") {
+    super();
+  }
+
+  render(): string {
+    const base = JSON.stringify(this.baseUrl);
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GitHub Profile Trophy</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #f9f9f8;
+      --surface: #ffffff;
+      --text: #18181b;
+      --muted: #71717a;
+      --subtle: #a1a1aa;
+      --border: #e4e4e7;
+      --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      --mono: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+    }
+    body {
+      font-family: var(--font);
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 64px 24px 48px;
+    }
+    header {
+      text-align: center;
+      margin-bottom: 40px;
+    }
+    .wordmark {
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--subtle);
+      margin-bottom: 20px;
+    }
+    header h1 {
+      font-size: 26px;
+      font-weight: 300;
+      letter-spacing: -0.02em;
+      color: var(--text);
+      line-height: 1.3;
+      margin-bottom: 8px;
+    }
+    header p {
+      font-size: 14px;
+      color: var(--muted);
+    }
+    main {
+      width: 100%;
+      max-width: 460px;
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+    }
+    .panel {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      padding: 28px 32px;
+    }
+    .panel-label {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--subtle);
+      margin-bottom: 14px;
+    }
+    .url-wrap {
+      display: flex;
+      align-items: stretch;
+      border: 1px solid var(--border);
+    }
+    .url-text {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--text);
+      padding: 10px 14px;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      background: var(--bg);
+      line-height: 1.5;
+    }
+    .copy-btn {
+      font-family: var(--font);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 0 16px;
+      background: var(--surface);
+      color: var(--muted);
+      border: none;
+      border-left: 1px solid var(--border);
+      cursor: pointer;
+      transition: color 0.15s;
+      white-space: nowrap;
+    }
+    .copy-btn:hover { color: var(--text); }
+    .copy-feedback {
+      font-size: 11px;
+      color: var(--subtle);
+      margin-top: 8px;
+      height: 16px;
+      letter-spacing: 0.04em;
+    }
+    form {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    label {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--subtle);
+    }
+    input {
+      font-family: var(--font);
+      font-size: 14px;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      outline: none;
+      -webkit-appearance: none;
+      border-radius: 0;
+      transition: border-color 0.15s;
+    }
+    input:focus { border-color: var(--text); }
+    input::placeholder { color: #c4c4c8; }
+    .hint {
+      font-size: 12px;
+      color: var(--subtle);
+      line-height: 1.5;
+    }
+    .hint a {
+      color: var(--muted);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+    .hint a:hover { color: var(--text); }
+    button[type="submit"] {
+      font-family: var(--font);
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      padding: 11px 24px;
+      background: var(--text);
+      color: var(--surface);
+      border: none;
+      cursor: pointer;
+      align-self: flex-start;
+      transition: opacity 0.15s;
+    }
+    button[type="submit"]:hover { opacity: 0.75; }
+  </style>
+</head>
+<body>
+  <header>
+    <p class="wordmark">GitHub Profile Trophy</p>
+    <h1>Generate your trophy card</h1>
+    <p>Display your GitHub stats as trophies in your profile README</p>
+  </header>
+  <main>
+    <div class="panel">
+      <p class="panel-label">Your URL</p>
+      <div class="url-wrap">
+        <span class="url-text" id="url-display">${this.baseUrl}?username=USERNAME</span>
+        <button class="copy-btn" type="button" id="copy-btn">Copy</button>
+      </div>
+      <p class="copy-feedback" id="copy-feedback"></p>
+    </div>
+    <div class="panel">
+      <p class="panel-label">Get trophies</p>
+      <form action="${this.baseUrl}" method="get">
+        <div class="field">
+          <label for="username">GitHub username</label>
+          <input
+            type="text"
+            name="username"
+            id="username"
+            placeholder="e.g. torvalds"
+            required
+            autocomplete="off"
+            autocapitalize="none"
+            spellcheck="false"
+          >
+        </div>
+        <div class="field">
+          <label for="theme">Theme <span style="opacity:0.4;font-weight:400;letter-spacing:0;">optional</span></label>
+          <input type="text" name="theme" id="theme" placeholder="e.g. onedark, nord, flat">
+          <p class="hint">Browse all themes in the <a href="https://github.com/ryo-ma/github-profile-trophy?tab=readme-ov-file#apply-theme" target="_blank" rel="noopener">documentation</a></p>
+        </div>
+        <button type="submit">View trophies</button>
+      </form>
+    </div>
+  </main>
+  <script>
+    const copyBtn = document.getElementById('copy-btn');
+    const feedback = document.getElementById('copy-feedback');
+    const usernameInput = document.getElementById('username');
+    const urlDisplay = document.getElementById('url-display');
+    const base = ${base};
+
+    usernameInput.addEventListener('input', () => {
+      const val = usernameInput.value.trim();
+      urlDisplay.textContent = val
+        ? base + '?username=' + encodeURIComponent(val)
+        : base + '?username=USERNAME';
+    });
+
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(urlDisplay.textContent).then(() => {
+        feedback.textContent = 'Copied to clipboard';
+        setTimeout(() => { feedback.textContent = ''; }, 2000);
+      });
+    });
+  </script>
+</body>
+</html>`;
+  }
 }
 
 export class Error419 extends BaseError {
   readonly status = 419;
   readonly message = "Rate Limit Exceeded";
+
+  protected renderContent(): string {
+    return `<p class="detail">Too many requests. Please wait a moment and try again.</p>`;
+  }
 }
 
 export class Error404 extends BaseError {
   readonly status = 404;
   readonly message = "Not Found";
+
+  constructor(readonly content?: string) {
+    super();
+  }
+
+  protected renderContent(): string {
+    return this.content ? `<p class="detail">${this.content}</p>` : "";
+  }
 }

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -48,19 +48,19 @@ export const getNextRankBar = (
     </style>
     <rect
       x="15"
-      y="101"
+      y="102"
       rx="1"
       width="${maxWidth}"
-      height="3.2"
-      opacity="0.3"
+      height="2"
+      opacity="0.2"
       fill="${color}"
     />
     <rect
       id="${title}-rank-progress"
       x="15"
-      y="101"
+      y="102"
       rx="1"
-      height="3.2"
+      height="2"
       fill="${color}"
     />
   `;

--- a/src/trophy.ts
+++ b/src/trophy.ts
@@ -86,18 +86,19 @@ export class Trophy {
           <rect
             x="0.5"
             y="0.5"
-            rx="4.5"
+            rx="3"
             width="${panelSize - 1}"
             height="${panelSize - 1}"
-            stroke="#e1e4e8"
+            stroke="#e4e4e7"
+            stroke-width="0.8"
             fill="${PRIMARY}"
             stroke-opacity="${noFrame ? "0" : "1"}"
             fill-opacity="${noBackground ? "0" : "1"}"
           />
           ${getTrophyIcon(theme, this.rank)}
-          <text x="50%" y="18" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="13" fill="${SECONDARY}">${this.title}</text>
-          <text x="50%" y="85" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10.5" fill="${TEXT}">${this.topMessage}</text>
-          <text x="50%" y="97" text-anchor="middle" font-family="Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji" font-weight="bold" font-size="10" fill="${TEXT}">${this.bottomMessage}</text>
+          <text x="50%" y="18" text-anchor="middle" font-family="'Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="600" font-size="12" fill="${SECONDARY}">${this.title}</text>
+          <text x="50%" y="85" text-anchor="middle" font-family="'Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="400" font-size="10" fill="${TEXT}">${this.topMessage}</text>
+          <text x="50%" y="97" text-anchor="middle" font-family="'Helvetica Neue',Helvetica,Arial,sans-serif" font-weight="400" font-size="9.5" fill="${TEXT}">${this.bottomMessage}</text>
           ${nextRankBar}
         </svg>
         `;


### PR DESCRIPTION
Replace the old landing page with a luxury minimal design — no shadows, thin borders, spaced uppercase labels, live URL preview, and a clean centered error page for 404/419. Refactor Error400 to own its HTML instead of receiving it as a raw string from the route handler.

Refine trophy SVG: lighter/thinner border, cleaner font stack, lighter text weights, and a slimmer progress bar.

Fix GithubApiService to detect fulfilled-but-ServiceError query results, resolving false 404s for valid usernames when tokens are misconfigured.