### PR TITLE
Change GitHub Action to use ryo-ma's trophy generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,11 +604,7 @@ Usage:
 
 ```yaml
 - name: Generate trophy
-  uses: Erik-Donath/github-profile-trophy@feature/generate-svg
-  with:
-    username: your-username
-    output_path: trophy.svg
-    token: ${{ secrets.GITHUB_TOKEN }}
+  uses: ryo-ma/github-profile-trophy@master
 ```
 
 # Contribution Guide


### PR DESCRIPTION
DEPENDS ON: https://github.com/ryo-ma/github-profile-trophy/pull/437

Updated GitHub Action usage to use ryo-ma's repository.