### PR TITLE
fix: remove unsupported 'public' property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "public": true,
   "functions": {
     "api/**/*.[jt]s": {
       "runtime": "vercel-deno@3.1.1",


### PR DESCRIPTION
<img width="658" height="583" alt="image" src="https://github.com/user-attachments/assets/c65c1905-c294-4436-adcc-c7f25dc08838" />

https://vercel.com/docs/project-configuration