### PR TITLE
fix: update imports for Deno 2.x compatibility (#448)

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -2,7 +2,7 @@ import { Card } from "../src/card.ts";
 import { CONSTANTS, parseParams } from "../src/utils.ts";
 import { COLORS, Theme } from "../src/theme.ts";
 import { Error400 } from "../src/error_page.ts";
-import "https://deno.land/x/dotenv@v0.5.0/load.ts";
+import "@std/dotenv/load";
 import { staticRenderRegeneration } from "../src/StaticRenderRegeneration/index.ts";
 import { GithubRepositoryService } from "../src/Repository/GithubRepository.ts";
 import { GithubApiService } from "../src/Services/GithubApiService.ts";

--- a/deno.json
+++ b/deno.json
@@ -5,5 +5,8 @@
     "format": "deno fmt",
     "lint": "deno lint",
     "test": "ENV_TYPE=test deno test --allow-env"
+  },
+  "imports": {
+    "@std/dotenv": "jsr:@std/dotenv@^0.224.0"
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.125.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import requestHandler from "./api/index.ts";
 
 serve(requestHandler, { port: Number(Deno.env.get("PORT")) || 8080 });


### PR DESCRIPTION
Fixes #448
The `std@0.125.0/http/server.ts` module was removed in Deno 2.x,
causing `deno task start` to fail and breaking the deployment.
Changes:
- Updated `main.ts`: std import from 0.125.0 → 0.224.0
- Updated `api/index.ts`: replaced deprecated dotenv@v0.5.0 
  import with JSR-compatible `@std/dotenv/load`
- Updated `deno.json`: added imports map for `@std/dotenv`
This restores compatibility with Deno 2.x and unblocks 
the paused deployment (#439).