### PR TITLE
fix: migrate Deno standard library imports to JSR

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: ["1.44.4"]
+        deno-version: ["1.44.4", "2.x"]
 
     steps:
       # Step 1: Checkout repository
@@ -24,7 +24,7 @@ jobs:
 
       # Step 2: Setup Deno
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: ${{ matrix.deno-version }}
 
@@ -37,9 +37,9 @@ jobs:
       - name: Deno format check
         run: deno fmt --check
 
-      # Step 5: Lint check (won't fail workflow)
+      # Step 5: Lint check
       - name: Deno lint check
-        run: deno lint || true
+        run: deno lint
 
       # Step 6: Run tests
       - name: Test Deno Module

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,9 @@
     "lint": "deno lint",
     "test": "ENV_TYPE=test deno test --allow-env"
   },
+  "fmt": {
+    "indentWidth": 2
+  },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.7",

--- a/deno.json
+++ b/deno.json
@@ -7,6 +7,12 @@
     "test": "ENV_TYPE=test deno test --allow-env"
   },
   "imports": {
-    "@std/dotenv": "jsr:@std/dotenv@^0.224.0"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/dotenv": "jsr:@std/dotenv@^0.225.7",
+    "@std/http": "jsr:@std/http@^1.1.2",
+    "@std/testing": "jsr:@std/testing@^1.0.19",
+    "@redis": "https://deno.land/x/redis@v0.31.0/mod.ts",
+    "@soxa": "https://deno.land/x/soxa@1.4/src/core/Soxa.ts",
+    "@soxa/defaults": "https://deno.land/x/soxa@1.4/src/defaults.ts"
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,21 +1,9 @@
-import { Soxa as ServiceProvider } from "https://deno.land/x/soxa@1.4/src/core/Soxa.ts";
-import { defaults } from "https://deno.land/x/soxa@1.4/src/defaults.ts";
-import {
-  assertEquals,
-  assertRejects,
-} from "https://deno.land/std@0.203.0/assert/mod.ts";
-import {
-  assertSpyCalls,
-  returnsNext,
-  spy,
-  stub,
-} from "https://deno.land/std@0.203.0/testing/mock.ts";
+import { Soxa as ServiceProvider } from "@soxa";
+import { defaults } from "@soxa/defaults";
+import { assertEquals, assertRejects } from "@std/assert";
+import { assertSpyCalls, returnsNext, spy, stub } from "@std/testing/mock";
 
-export {
-  type Bulk,
-  connect,
-  type Redis,
-} from "https://deno.land/x/redis@v0.31.0/mod.ts";
+export { type Bulk, connect, type Redis } from "@redis";
 
 import { CONSTANTS } from "./src/utils.ts";
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { serve } from "@std/http/server";
 import requestHandler from "./api/index.ts";
 
 serve(requestHandler, { port: Number(Deno.env.get("PORT")) || 8080 });

--- a/render_svg.ts
+++ b/render_svg.ts
@@ -1,4 +1,4 @@
-import "https://deno.land/x/dotenv@v0.5.0/load.ts";
+import "@std/dotenv/load";
 
 const username = Deno.args[0];
 const outputPath = Deno.args[1] ?? "./assets/trophy.svg";
@@ -14,6 +14,7 @@ if (!username) {
 import { GithubApiService } from "./src/Services/GithubApiService.ts";
 import { Card } from "./src/card.ts";
 import { COLORS } from "./src/theme.ts";
+import { UserInfo } from "./src/user_info.ts";
 
 async function main() {
   console.log("Starting trophy render...");
@@ -25,16 +26,14 @@ async function main() {
 
   const userInfoOrError = await svc.requestUserInfo(username);
 
-  if (
-    !(userInfoOrError && (userInfoOrError as any).totalCommits !== undefined)
-  ) {
+  if (!(userInfoOrError instanceof UserInfo)) {
     console.error(
       "Failed to fetch user info. Check token, username and rate limits.",
     );
     Deno.exit(2);
   }
 
-  const userInfo = userInfoOrError as any;
+  const userInfo = userInfoOrError;
 
   const panelSize = 115;
   const maxRow = 10;
@@ -55,7 +54,7 @@ async function main() {
     noBackground,
     noFrame,
   );
-  const theme = (COLORS as any)[themeName] ?? (COLORS as any).default;
+  const theme = COLORS[themeName] ?? COLORS.default;
   const svg = card.render(userInfo, theme);
 
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,14 @@
 {
-    "functions": {
-        "api/**/*.[jt]s": {
-            "runtime": "vercel-deno@3.1.1",
-            "maxDuration": 5
-        }
-    },
-    "rewrites": [
-        {
-            "source": "/(.*)",
-            "destination": "/api/$1"
-        }
-    ]
+  "functions": {
+    "api/**/*.[jt]s": {
+      "runtime": "vercel-deno@3.1.1",
+      "maxDuration": 5
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/api/$1"
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,14 @@
 {
-  "functions": {
-    "api/**/*.[jt]s": {
-      "runtime": "vercel-deno@3.1.1",
-      "maxDuration": 5
-    }
-  },
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/api/$1"
-    }
-  ]
+    "functions": {
+        "api/**/*.[jt]s": {
+            "runtime": "vercel-deno@3.1.1",
+            "maxDuration": 5
+        }
+    },
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/api/$1"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary

- Move standard library imports to JSR aliases.
- Declare all dependency aliases in `deno.json`.
- Replace `any` values in `render_svg.ts`.
- Use a Deno 1.44.4 and Deno 2.x CI matrix.
- Make lint errors fail CI.

## Root cause

The project used mixed `deno.land/std` versions and JSR imports.
Deno 2 lint rejects inline dependency URLs.
The former CI only ran Deno 1.44.4. It ignored lint errors.

## Local Deno 2 validation

Validated with Deno 2.9.0.

- `deno fmt --check`
- `deno lint`
- `deno test --allow-env`

Closes #455